### PR TITLE
Clone response before passing it to function

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,14 @@ In order to deploy using `https://deploy.workers.cloudflare.com` you'll need to 
 
 To deploy the worker using [Wrangler](https://github.com/cloudflare/wrangler) please fork this repository and run after setting Wrangler up:
 
-`wrangler publish`
+`wrangler deploy`
 
 ## Configuration
 
 This worker will require two secrets variables that you can setup in the dashboard:
 
-`LEVO_ORG_ID`
-`LEVO_SATELLITE_URL`
+* `LEVO_ORG_ID`
+* `LEVO_SATELLITE_URL`
 
 ### Configure secrets in CloudFlare dashboard
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,7 +58,7 @@ async function sendToLevo(
 	}1.0/har`;
 	const harLog = await buildHarFromRequestResponse(
 		request,
-		response,
+		response.clone(),
 	);
 	const levo_request = new Request(levo_url, {
 		method: "POST",


### PR DESCRIPTION
- Update README.md
- Clone response before passing it to function
  This is done to avoid the following error in the worker:

  > Body has already been used. It can only be used once.
  
  It was introduced in #2.
